### PR TITLE
task-178. Support [Bearer/Personal access token] login to jira

### DIFF
--- a/src/Pet.Jira.Application/Authentication/AuthenticationType.cs
+++ b/src/Pet.Jira.Application/Authentication/AuthenticationType.cs
@@ -1,0 +1,8 @@
+﻿namespace Pet.Jira.Application.Authentication
+{
+    public enum AuthenticationType
+    {
+        Basic,
+        Bearer        
+    }
+}

--- a/src/Pet.Jira.Application/Authentication/BasicLoginRequest.cs
+++ b/src/Pet.Jira.Application/Authentication/BasicLoginRequest.cs
@@ -2,7 +2,7 @@
 
 namespace Pet.Jira.Application.Authentication
 {
-    public class LoginRequest
+    public class BasicLoginRequest
     {
         [Required]
         public string Username { get; set; }

--- a/src/Pet.Jira.Application/Authentication/BearerLoginRequest.cs
+++ b/src/Pet.Jira.Application/Authentication/BearerLoginRequest.cs
@@ -1,0 +1,10 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace Pet.Jira.Application.Authentication
+{
+    public class BearerLoginRequest
+    {
+        [Required]
+        public string Token { get; set; }
+    }
+}

--- a/src/Pet.Jira.Application/Authentication/Commands/BasicLogin.cs
+++ b/src/Pet.Jira.Application/Authentication/Commands/BasicLogin.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Security.Authentication;
+using MediatR;
+using Pet.Jira.Application.Authentication;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Pet.Jira.Application.Authentication.Commands
+{
+    public class BasicLogin
+    {
+        public class Command : IRequest<Model>
+        {
+            public Command(BasicLoginRequest request)
+            {
+                _request = request;
+            }
+
+            private readonly BasicLoginRequest _request;
+            public BasicLoginRequest Request => _request;
+        }
+
+        public class Model
+        {
+            public LoginResponse Response { get; set; }
+        }
+
+        public class Handler : IRequestHandler<Command, Model>
+        {
+            private readonly IAuthenticationService _authenticationService;
+
+            public Handler(IAuthenticationService authenticationService)
+            {
+                _authenticationService = authenticationService;
+            }
+
+            public async Task<Model> Handle(
+                Command command,
+                CancellationToken cancellationToken)
+            {
+                try
+                {
+                    var loginResult = await _authenticationService.LoginAsync(command.Request);
+                    return new Model { Response = loginResult };
+                }
+                catch (AuthenticationException e)
+                {
+                    throw new Exception($"Authentication exception [{command?.Request?.Username}]") { Source = e.Source };
+                }
+            }
+        }
+    }
+}

--- a/src/Pet.Jira.Application/Authentication/Commands/BearerLogin.cs
+++ b/src/Pet.Jira.Application/Authentication/Commands/BearerLogin.cs
@@ -1,23 +1,22 @@
-﻿using System;
+﻿using MediatR;
+using System;
 using System.Security.Authentication;
-using MediatR;
-using Pet.Jira.Application.Authentication;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Pet.Jira.Application.Worklogs.Commands
+namespace Pet.Jira.Application.Authentication.Commands
 {
-    public class Login
+    public class BearerLogin
     {
         public class Command : IRequest<Model>
         {
-            public Command(LoginRequest request)
+            public Command(BearerLoginRequest request)
             {
                 _request = request;
             }
 
-            private readonly LoginRequest _request;
-            public LoginRequest Request => _request;
+            private readonly BearerLoginRequest _request;
+            public BearerLoginRequest Request => _request;
         }
 
         public class Model
@@ -45,7 +44,7 @@ namespace Pet.Jira.Application.Worklogs.Commands
                 }
                 catch (AuthenticationException e)
                 {
-                    throw new Exception($"Authentication exception [{command?.Request?.Username}]") { Source = e.Source };
+                    throw new Exception($"Authentication exception [{command?.Request?.Token}]") { Source = e.Source };
                 }
             }
         }

--- a/src/Pet.Jira.Application/Authentication/Dto/LoginDto.cs
+++ b/src/Pet.Jira.Application/Authentication/Dto/LoginDto.cs
@@ -8,15 +8,29 @@ namespace Pet.Jira.Application.Authentication.Dto
         public Guid Id { get; set; }
         public string Username { get; set; }
         public string Password { get; set; }
+        public string PersonalAccessToken { get; set; }
+        public AuthenticationType AuthenticationType { get; set; }
         public Guid Key => Id;
 
-        public static LoginDto Create(LoginRequest request)
+        public static LoginDto Create(BasicLoginRequest request)
         {
             return new LoginDto
             {
                 Id = Guid.NewGuid(),
                 Username = request.Username,
-                Password = request.Password
+                Password = request.Password,
+                AuthenticationType = AuthenticationType.Basic
+            };
+        }
+
+        public static LoginDto Create(BearerLoginRequest request, LoginResponse response)
+        {
+            return new LoginDto
+            {
+                Id = Guid.NewGuid(),
+                PersonalAccessToken = request.Token,
+                AuthenticationType = AuthenticationType.Bearer,
+                Username = response.Username
             };
         }
     }

--- a/src/Pet.Jira.Application/Authentication/IAuthenticationService.cs
+++ b/src/Pet.Jira.Application/Authentication/IAuthenticationService.cs
@@ -4,6 +4,7 @@ namespace Pet.Jira.Application.Authentication
 {
     public interface IAuthenticationService
     {
-        Task<LoginResponse> LoginAsync(LoginRequest request);
+        Task<LoginResponse> LoginAsync(BasicLoginRequest request);
+        Task<LoginResponse> LoginAsync(BearerLoginRequest request);
     }
 }

--- a/src/Pet.Jira.Application/Authentication/LoginResponse.cs
+++ b/src/Pet.Jira.Application/Authentication/LoginResponse.cs
@@ -15,5 +15,6 @@
 
         public bool IsSuccess { get; set; }
         public string ErrorMessage { get; set; }
+        public string Username { get; set; }
     }
 }

--- a/src/Pet.Jira.Domain/Models/Users/User.cs
+++ b/src/Pet.Jira.Domain/Models/Users/User.cs
@@ -6,6 +6,7 @@ namespace Pet.Jira.Domain.Models.Users
     {
         public string Username { get; set; }
         public string Password { get; set; }
+        public string PersonalAccessToken { get; set; }
 
         public string Key => Username;
     }

--- a/src/Pet.Jira.Infrastructure/Authentication/AuthenticationService.cs
+++ b/src/Pet.Jira.Infrastructure/Authentication/AuthenticationService.cs
@@ -13,7 +13,12 @@ namespace Pet.Jira.Infrastructure.Authentication
             _jiraService = jiraService;
         }
 
-        public async Task<LoginResponse> LoginAsync(LoginRequest request)
+        public async Task<LoginResponse> LoginAsync(BasicLoginRequest request)
+        {
+            return await _jiraService.LoginAsync(request);
+        }
+
+        public async Task<LoginResponse> LoginAsync(BearerLoginRequest request)
         {
             return await _jiraService.LoginAsync(request);
         }

--- a/src/Pet.Jira.Infrastructure/Jira/IJiraService.cs
+++ b/src/Pet.Jira.Infrastructure/Jira/IJiraService.cs
@@ -46,7 +46,11 @@ namespace Pet.Jira.Infrastructure.Jira
             CancellationToken cancellationToken = default);
 
         Task<LoginResponse> LoginAsync(
-            LoginRequest request,
+            BasicLoginRequest request,
+            CancellationToken cancellationToken = default);
+
+        Task<LoginResponse> LoginAsync(
+            BearerLoginRequest request,
             CancellationToken cancellationToken = default);
 
         Task AddWorklogAsync(

--- a/src/Pet.Jira.Infrastructure/Mock/MockAuthenticationService.cs
+++ b/src/Pet.Jira.Infrastructure/Mock/MockAuthenticationService.cs
@@ -5,9 +5,14 @@ namespace Pet.Jira.Infrastructure.Mock
 {
     internal class MockAuthenticationService : IAuthenticationService
     {
-        public Task<LoginResponse> LoginAsync(LoginRequest request)
+        public Task<LoginResponse> LoginAsync(BasicLoginRequest request)
         {
             return Task.FromResult(new LoginResponse(true));
+        }
+
+        public Task<LoginResponse> LoginAsync(BearerLoginRequest request)
+        {
+            return Task.FromResult(new LoginResponse(true) { Username = request.Token });
         }
     }
 }

--- a/src/Pet.Jira.Web/Authentication/AuthenticationMiddleware.cs
+++ b/src/Pet.Jira.Web/Authentication/AuthenticationMiddleware.cs
@@ -2,8 +2,10 @@
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Http;
 using Pet.Jira.Application.Authentication;
+using Pet.Jira.Application.Authentication.Dto;
 using Pet.Jira.Web.Common;
 using System;
+using System.Collections.Generic;
 using System.Security.Claims;
 using System.Threading.Tasks;
 
@@ -33,11 +35,18 @@ namespace Pet.Jira.Web.Authentication
                     return;
                 }
 
-                var claims = new Claim[]
+                var claims = new List<Claim>
                 {
-                    new Claim(ClaimTypes.Name, login.Username),
-                    new Claim(ClaimTypes.UserData, login.Password)
+                    new Claim(ClaimTypes.Name, login.Username)
                 };
+                if (login.Password != null)
+                {
+                    claims.Add(new Claim(ClaimTypes.UserData, login.Password));
+                }
+                if (login.PersonalAccessToken != null)
+                {
+                    claims.Add(new Claim(nameof(LoginDto.PersonalAccessToken), login.PersonalAccessToken));
+                }
                 var claimsIdentity = new ClaimsIdentity(
                     claims, CookieAuthenticationDefaults.AuthenticationScheme);
                 

--- a/src/Pet.Jira.Web/Authentication/IdentityService.cs
+++ b/src/Pet.Jira.Web/Authentication/IdentityService.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Components.Authorization;
 using Pet.Jira.Application.Authentication;
+using Pet.Jira.Application.Authentication.Dto;
 using Pet.Jira.Domain.Models.Users;
 using System.Linq;
 using System.Security.Claims;
@@ -28,6 +29,9 @@ namespace Pet.Jira.Web.Authentication
                     Username = user.Identity.Name,
                     Password = user.Claims
                         .FirstOrDefault(claim => claim.Type == ClaimTypes.UserData)?
+                        .Value,
+                    PersonalAccessToken = user.Claims
+                        .FirstOrDefault(claim => claim.Type == nameof(LoginDto.PersonalAccessToken))?
                         .Value
                 }
                 : null;

--- a/src/Pet.Jira.Web/Components/Authentication/Login.razor
+++ b/src/Pet.Jira.Web/Components/Authentication/Login.razor
@@ -5,14 +5,30 @@
     <MudProgressCircular Color="Color.Primary" Indeterminate="true" />
 </MudOverlay>
 
-<MudCard Outlined="true" @onkeyup="@OnKeyUp">
-    <MudCardContent>
-        <MudTextField @bind-Value="Model.LoginRequest.Username" Label="Username" Variant="Variant.Text"/>
-        <MudTextField @bind-Value="Model.LoginRequest.Password" Label="Password" Variant="Variant.Text" InputType="InputType.Password"/>
-    </MudCardContent>
-    <MudCardActions>
-        <MudButton OnClick="LoginUser" Variant="Variant.Filled" Color="Color.Primary">Login</MudButton>
-    </MudCardActions>
-</MudCard>
+<MudTabs Elevation="2" Rounded="true" Color="@Color.Primary">
+    <MudTabPanel Text="Basic">
+        <MudCard Outlined="true" @onkeyup="@BasicOnKeyUp">
+            <MudCardContent>
+                <MudTextField @bind-Value="Model.BasicLoginRequest.Username" Label="Username" Variant="Variant.Text" />
+                <MudTextField @bind-Value="Model.BasicLoginRequest.Password" Label="Password" Variant="Variant.Text" InputType="InputType.Password" />
+            </MudCardContent>
+            <MudCardActions>
+                <MudButton OnClick="BasicLogin" Variant="Variant.Filled" Color="Color.Primary">Login</MudButton>
+            </MudCardActions>
+        </MudCard>
+    </MudTabPanel>
+    <MudTabPanel Text="Bearer">
+        <MudCard Outlined="true" @onkeyup="@BearerOnKeyUp">
+            <MudCardContent>
+                <MudTextField @bind-Value="Model.BearerLoginRequest.Token" Label="Personal access token" Variant="Variant.Text" />
+            </MudCardContent>
+            <MudCardActions>
+                <MudButton OnClick="BearerLogin" Variant="Variant.Filled" Color="Color.Primary">Login</MudButton>
+            </MudCardActions>
+        </MudCard>
+    </MudTabPanel>
+</MudTabs>
 
-@code {}
+
+@code {
+    }

--- a/src/Pet.Jira.Web/Components/Authentication/Login.razor
+++ b/src/Pet.Jira.Web/Components/Authentication/Login.razor
@@ -21,6 +21,7 @@
         <MudCard Outlined="true" @onkeyup="@BearerOnKeyUp">
             <MudCardContent>
                 <MudTextField @bind-Value="Model.BearerLoginRequest.Token" Label="Personal access token" Variant="Variant.Text" />
+                <MudLink Typo=Typo.overline Color=Color.Default Href="https://confluence.atlassian.com/enterprise/using-personal-access-tokens-1026032365.html#UsingPersonalAccessTokens-CreatingPATsintheapplication">How to create personal access token?</MudLink>
             </MudCardContent>
             <MudCardActions>
                 <MudButton OnClick="BearerLogin" Variant="Variant.Filled" Color="Color.Primary">Login</MudButton>

--- a/src/Pet.Jira.Web/Components/Authentication/Login.razor.cs
+++ b/src/Pet.Jira.Web/Components/Authentication/Login.razor.cs
@@ -3,8 +3,6 @@ using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using Pet.Jira.Application.Authentication;
 using Pet.Jira.Application.Authentication.Dto;
-using Pet.Jira.Application.Storage;
-using Pet.Jira.Domain.Models.Users;
 using Pet.Jira.Web.Components.Common;
 using Pet.Jira.Web.Shared;
 using System;
@@ -17,31 +15,58 @@ namespace Pet.Jira.Web.Components.Authentication
         [Inject] private NavigationManager NavigationManager { get; set; }
         [Inject] private IMediator Mediator { get; set; }
         [Inject] private ILoginMemoryCache LoginMemoryCache { get; set; }
-        [Inject] private IStorage<string, UserProfile> _userProfileStorage { get; set; }
-        [Inject] private IDataSource<string, UserProfile> _userProfileDataSource { get; set; }
-        [Inject] private IIdentityService _identityService { get; set; }
         [CascadingParameter] public ErrorHandler ErrorHandler { get; set; }
 
         private readonly ComponentModel Model = ComponentModel.Create();
 
-        public async Task OnKeyUp(KeyboardEventArgs keyboardEventArgs)
+        public async Task BasicOnKeyUp(KeyboardEventArgs keyboardEventArgs)
         {
             switch (keyboardEventArgs.Code)
             {
                 case "Enter":
                 case "NumpadEnter":
-                    await LoginUser();
+                    await BasicLogin();
                     break;
             }
         }
 
-        private async Task LoginUser()
+        public async Task BearerOnKeyUp(KeyboardEventArgs keyboardEventArgs)
+        {
+            switch (keyboardEventArgs.Code)
+            {
+                case "Enter":
+                case "NumpadEnter":
+                    await BearerLogin();
+                    break;
+            }
+        }
+
+        private async Task BasicLogin()
+        {
+            async Task<LoginDto> loginFunction()
+            {
+                await Mediator.Send(new Application.Authentication.Commands.BasicLogin.Command(Model.BasicLoginRequest));
+                return LoginDto.Create(Model.BasicLoginRequest);
+            }
+            await BaseLogin(loginFunction);
+        }
+
+        private async Task BearerLogin()
+        {
+            async Task<LoginDto> loginFunction()
+            {
+                var response = await Mediator.Send(new Application.Authentication.Commands.BearerLogin.Command(Model.BearerLoginRequest));
+                return LoginDto.Create(Model.BearerLoginRequest, response.Response);
+            }
+            await BaseLogin(loginFunction);
+        }
+
+        private async Task BaseLogin(Func<Task<LoginDto>> loginFunction)
         {
             try
             {
                 Model.StateTo(ComponentModelState.InProgress);
-                await Mediator.Send(new Application.Worklogs.Commands.Login.Command(Model.LoginRequest));
-                var loginDto = LoginDto.Create(Model.LoginRequest);
+                var loginDto = await loginFunction.Invoke();
                 LoginMemoryCache.TryAdd(loginDto);
                 NavigationManager.NavigateTo($"/login?key={loginDto.Id}", true);
             }
@@ -62,7 +87,8 @@ namespace Pet.Jira.Web.Components.Authentication
                 return new ComponentModel();
             }
 
-            public LoginRequest LoginRequest { get; set; } = new LoginRequest();
+            public BasicLoginRequest BasicLoginRequest { get; set; } = new BasicLoginRequest();
+            public BearerLoginRequest BearerLoginRequest { get; set; } = new BearerLoginRequest();
         }
     }
 }


### PR DESCRIPTION
Added second authentication method:
* Bearer (or Personal) access token

See more [here](https://confluence.atlassian.com/enterprise/using-personal-access-tokens-1026032365.html#UsingPersonalAccessTokens-CreatingPATsintheapplication)

Now there is no need to enter the user's login and password

![image](https://github.com/tolmachev-pravo/pet-jira-workflow/assets/62241382/2e56062e-34f9-49ab-9747-6578ad0f5e66)
