### PR TITLE
task-182. Custom worklog

### DIFF
--- a/src/Pet.Jira.Application/Issues/IIssueDataSource.cs
+++ b/src/Pet.Jira.Application/Issues/IIssueDataSource.cs
@@ -15,5 +15,9 @@ namespace Pet.Jira.Application.Issues
         Task<string> GetIssueOpenPullRequestUrlAsync(
             GetIssueOpenPullRequestUrl.Query query,
             CancellationToken cancellationToken = default);
-    }
+
+		Task<Issue> GetIssueAsync(
+            string issueKey,
+            CancellationToken cancellationToken = default);
+	}
 }

--- a/src/Pet.Jira.Application/Pet.Jira.Application.csproj
+++ b/src/Pet.Jira.Application/Pet.Jira.Application.csproj
@@ -5,6 +5,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="Issues\Dto\**" />
+    <EmbeddedResource Remove="Issues\Dto\**" />
+    <None Remove="Issues\Dto\**" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Pet.Jira.Domain\Pet.Jira.Domain.csproj" />
   </ItemGroup>
 
@@ -13,10 +19,6 @@
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="11.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
     <PackageReference Include="TimeZoneConverter" Version="6.0.1" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="Issues\Dto\" />
   </ItemGroup>
 
 </Project>

--- a/src/Pet.Jira.Application/Storage/BaseMemoryCache.cs
+++ b/src/Pet.Jira.Application/Storage/BaseMemoryCache.cs
@@ -1,5 +1,6 @@
 ﻿using Pet.Jira.Domain.Models.Abstract;
 using System.Collections.Concurrent;
+using System.Threading.Tasks;
 
 namespace Pet.Jira.Application.Storage
 {
@@ -21,5 +22,8 @@ namespace Pet.Jira.Application.Storage
             _storage.TryGetValue(key, out TEntity oldEntity)
                 ? _storage.TryUpdate(key, newEntity, oldEntity)
                 : _storage.TryAdd(key, newEntity);
+
+        public virtual Task<ConcurrentDictionary<TKey, TEntity>> GetValuesAsync() =>
+            Task.FromResult(_storage);
     }
 }

--- a/src/Pet.Jira.Application/Storage/IMemoryCache.cs
+++ b/src/Pet.Jira.Application/Storage/IMemoryCache.cs
@@ -1,4 +1,7 @@
-﻿namespace Pet.Jira.Application.Storage
+﻿using System.Collections.Concurrent;
+using System.Threading.Tasks;
+
+namespace Pet.Jira.Application.Storage
 {
     public interface IMemoryCache<TKey, TEntity>
     {
@@ -6,5 +9,6 @@
         bool TryGetValue(TKey key, out TEntity entity);
         bool TryRemove(TKey key, out TEntity entity);
         bool TryUpdate(TKey key, TEntity entity);
+        Task<ConcurrentDictionary<TKey, TEntity>> GetValuesAsync();
     }
 }

--- a/src/Pet.Jira.Application/Worklogs/Dto/AddedWorklogDto.cs
+++ b/src/Pet.Jira.Application/Worklogs/Dto/AddedWorklogDto.cs
@@ -23,12 +23,19 @@ namespace Pet.Jira.Application.Worklogs.Dto
 
         private static string WorklogComment(WorkingDayWorklog worklog)
         {
+            if (!string.IsNullOrEmpty(worklog.Comment))
+            {
+                return worklog.Comment;
+            }
+
             switch (worklog.Source)
             {
                 case WorklogSource.Assignee:
                     return $"Working on task {worklog.Issue?.Key}";
                 case WorklogSource.Comment:
                     return $"Task discussion {worklog.Issue?.Key}";
+                case WorklogSource.Calendar:
+                    return $"Discussion {worklog.Issue?.Key}";
                 default:
                     return "Default worklog";
             }

--- a/src/Pet.Jira.Application/Worklogs/Dto/WorkingDayWorklog.cs
+++ b/src/Pet.Jira.Application/Worklogs/Dto/WorkingDayWorklog.cs
@@ -46,6 +46,8 @@ namespace Pet.Jira.Application.Worklogs.Dto
         public TimeSpan ChildrenTimeSpent => Children.TimeSpent();
         public bool IsEmpty => RemainingTimeSpent == TimeSpan.Zero;
 
+        public string Comment { get; set; }
+
         public WorkingDayWorklog()
         {
             Children = new List<WorkingDayWorklog>();
@@ -139,7 +141,8 @@ namespace Pet.Jira.Application.Worklogs.Dto
                 RemainingTimeSpent = RemainingTimeSpent,
                 Issue = Issue,
                 Type = type,
-                Source = Source
+                Source = Source,
+                Comment = Comment
             };
         }
 

--- a/src/Pet.Jira.Domain/Models/Issues/Issue.cs
+++ b/src/Pet.Jira.Domain/Models/Issues/Issue.cs
@@ -8,5 +8,7 @@ namespace Pet.Jira.Domain.Models.Issues
         public string Summary { get; set; }
         public string Link { get; set; }
         public string Identifier { get; set; }
-    }
+
+		public string Name => $"{Key}. {Summary}";
+	}
 }

--- a/src/Pet.Jira.Domain/Models/Worklogs/WorklogSource.cs
+++ b/src/Pet.Jira.Domain/Models/Worklogs/WorklogSource.cs
@@ -3,6 +3,7 @@
     public enum WorklogSource
     {
         Assignee,
-        Comment
+        Comment,
+        Calendar
     }
 }

--- a/src/Pet.Jira.Infrastructure/Jira/Dto/IssueDto.cs
+++ b/src/Pet.Jira.Infrastructure/Jira/Dto/IssueDto.cs
@@ -1,13 +1,15 @@
-﻿using Pet.Jira.Domain.Models.Issues;
+﻿using Pet.Jira.Domain.Models.Abstract;
+using Pet.Jira.Domain.Models.Issues;
 
 namespace Pet.Jira.Infrastructure.Jira.Dto
 {
-    public class IssueDto
+    public class IssueDto : IEntity<string>
     {
         public string Key { get; set; }
         public string Summary { get; set; }
         public string Link { get; set; }
         public string Identifier { get; set; }
+        public string Name => $"{Key}. {Summary}";
 
         public Issue Adapt()
         {

--- a/src/Pet.Jira.Infrastructure/Jira/IJiraConfiguration.cs
+++ b/src/Pet.Jira.Infrastructure/Jira/IJiraConfiguration.cs
@@ -3,5 +3,6 @@
     public interface IJiraConfiguration
     {
         string Url { get; set; }
+        string[] CachedIssues { get; set; }
     }
 }

--- a/src/Pet.Jira.Infrastructure/Jira/IJiraService.cs
+++ b/src/Pet.Jira.Infrastructure/Jira/IJiraService.cs
@@ -12,7 +12,15 @@ namespace Pet.Jira.Infrastructure.Jira
 {
     public interface IJiraService
     {
-        Task<IEnumerable<IssueDto>> GetIssuesAsync(
+        Task<Dictionary<string, IssueDto>> GetIssuesAsync(
+            string[] issueKeys,
+            CancellationToken cancellationToken = default);
+
+		Task<IssueDto> GetIssueAsync(
+            string issueKey,
+            CancellationToken cancellationToken = default);
+
+		Task<IEnumerable<IssueDto>> GetIssuesAsync(
             IssueSearchOptions issueSearchOptions,
             CancellationToken cancellationToken = default);
 

--- a/src/Pet.Jira.Infrastructure/Jira/IssueMemoryCache.cs
+++ b/src/Pet.Jira.Infrastructure/Jira/IssueMemoryCache.cs
@@ -1,0 +1,37 @@
+﻿using Microsoft.Extensions.Options;
+using Pet.Jira.Application.Extensions;
+using Pet.Jira.Application.Storage;
+using Pet.Jira.Domain.Models.Issues;
+using System.Collections.Concurrent;
+using System.Threading.Tasks;
+
+namespace Pet.Jira.Infrastructure.Jira
+{
+    public class IssueMemoryCache : BaseMemoryCache<string, Issue>
+    {
+        private readonly IJiraConfiguration _jiraConfiguration;
+        private readonly IJiraService _jiraService;
+
+        public IssueMemoryCache(
+            IOptions<JiraConfiguration> jiraConfiguration,
+            IJiraService jiraService)
+        {
+            _jiraConfiguration = jiraConfiguration.Value;
+            _jiraService = jiraService;
+        }
+
+        public override async Task<ConcurrentDictionary<string, Issue>> GetValuesAsync()
+        {
+            var storage = await base.GetValuesAsync();
+            if (storage.IsEmpty() && !_jiraConfiguration.CachedIssues.IsEmpty())
+            {
+                var issues = await _jiraService.GetIssuesAsync(_jiraConfiguration.CachedIssues);
+				foreach (var issue in issues)
+                {
+                    TryAdd(issue.Value.Adapt());
+                }
+            }
+            return await base.GetValuesAsync();
+        }
+    }
+}

--- a/src/Pet.Jira.Infrastructure/Jira/JiraConfiguration.cs
+++ b/src/Pet.Jira.Infrastructure/Jira/JiraConfiguration.cs
@@ -1,7 +1,10 @@
-﻿namespace Pet.Jira.Infrastructure.Jira
+﻿using System;
+
+namespace Pet.Jira.Infrastructure.Jira
 {
     public class JiraConfiguration : IJiraConfiguration
     {
         public string Url { get; set; }
+        public string[] CachedIssues { get; set; } = Array.Empty<string>();
     }
 }

--- a/src/Pet.Jira.Infrastructure/Jira/JiraExtensions.cs
+++ b/src/Pet.Jira.Infrastructure/Jira/JiraExtensions.cs
@@ -3,11 +3,20 @@ using Pet.Jira.Domain.Models.Worklogs;
 using Pet.Jira.Infrastructure.Jira.Dto;
 using System;
 using System.Collections.Generic;
+using System.Text.RegularExpressions;
 
 namespace Pet.Jira.Infrastructure.Jira
 {
     public static class JiraExtensions
     {
+        public static bool IsJiraKey(this string input)
+        {
+            var pattern = "^[A-Z][A-Z0-9]+-[0-9]+$";
+			var regex = new Regex(pattern);
+			var match = regex.Match(input);
+            return match.Success;
+		}
+
         public static IEnumerable<T> ConvertTo<T>(this IList<IssueChangeLogItemDto> issueChangeLogItems,
             string issueStatusId,
             ITimeProvider timeProvider,

--- a/src/Pet.Jira.Infrastructure/Jira/JiraIssueDataSource.cs
+++ b/src/Pet.Jira.Infrastructure/Jira/JiraIssueDataSource.cs
@@ -12,11 +12,11 @@ namespace Pet.Jira.Infrastructure.Jira
     {
         private readonly IJiraService _jiraService;
 
-        public JiraIssueDataSource(
+		public JiraIssueDataSource(
             IJiraService jiraService)
         {
             _jiraService = jiraService;
-        }
+		}
 
         public async Task<string> GetIssueOpenPullRequestUrlAsync(
             GetIssueOpenPullRequestUrl.Query query, CancellationToken cancellationToken = default)
@@ -58,5 +58,13 @@ namespace Pet.Jira.Infrastructure.Jira
                 Name = issueStatus.Name
             });
         }
-    }
+
+		public async Task<Issue> GetIssueAsync(
+            string issueKey,
+            CancellationToken cancellationToken = default)
+		{
+			var issue = await _jiraService.GetIssueAsync(issueKey, cancellationToken);
+            return issue?.Adapt();
+		}
+	}
 }

--- a/src/Pet.Jira.Infrastructure/Jira/JiraService.cs
+++ b/src/Pet.Jira.Infrastructure/Jira/JiraService.cs
@@ -81,10 +81,42 @@ namespace Pet.Jira.Infrastructure.Jira
         /// <summary>
         /// Get issues
         /// </summary>
-        /// <param name="issueSearchOptions"></param>
+        /// <param name="issueKeys"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        public async Task<IEnumerable<IssueDto>> GetIssuesAsync(
+        public async Task<Dictionary<string, IssueDto>> GetIssuesAsync(
+            string[] issueKeys,
+            CancellationToken cancellationToken = default)
+        {
+            var issues = await _jiraClient.Issues.GetIssuesAsync(issueKeys);
+            return issues.ToDictionary(
+                issue => issue.Key,
+                issue => IssueDto.Create(issue.Value, _linkGenerator));
+        }
+
+		/// <summary>
+		/// Get issue
+		/// </summary>
+		/// <param name="issueKey"></param>
+		/// <param name="cancellationToken"></param>
+		/// <returns></returns>
+		public async Task<IssueDto> GetIssueAsync(
+			string issueKey,
+			CancellationToken cancellationToken = default)
+		{
+			var issue = await _jiraClient.Issues.GetIssueAsync(issueKey);
+            return issue is null 
+                ? default
+                : IssueDto.Create(issue, _linkGenerator);
+		}
+
+		/// <summary>
+		/// Get issues
+		/// </summary>
+		/// <param name="issueSearchOptions"></param>
+		/// <param name="cancellationToken"></param>
+		/// <returns></returns>
+		public async Task<IEnumerable<IssueDto>> GetIssuesAsync(
             IssueSearchOptions issueSearchOptions,
             CancellationToken cancellationToken = default)
         {

--- a/src/Pet.Jira.Infrastructure/Mock/IssueGenerator.cs
+++ b/src/Pet.Jira.Infrastructure/Mock/IssueGenerator.cs
@@ -1,0 +1,20 @@
+﻿using Pet.Jira.Domain.Models.Issues;
+using System;
+
+namespace Pet.Jira.Infrastructure.Mock
+{
+	internal static class IssueGenerator
+	{
+		public static Issue Create(string key = null)
+		{
+			key ??= $"CASEM-{new Random().Next(1000, 10000)}";
+			var summary = TextGenerator.Create();
+			return new Issue
+			{
+				Key = key,
+				Summary = summary,
+				Link = "http://localhost"
+			};
+		}
+	}
+}

--- a/src/Pet.Jira.Infrastructure/Mock/MockIssueDataSource.cs
+++ b/src/Pet.Jira.Infrastructure/Mock/MockIssueDataSource.cs
@@ -9,7 +9,12 @@ namespace Pet.Jira.Infrastructure.Mock
 {
     internal class MockIssueDataSource : IIssueDataSource
     {
-        public async Task<string> GetIssueOpenPullRequestUrlAsync(GetIssueOpenPullRequestUrl.Query query, CancellationToken cancellationToken = default)
+		public async Task<Issue> GetIssueAsync(string issueKey, CancellationToken cancellationToken = default)
+		{
+			return await Task.FromResult(IssueGenerator.Create(issueKey));
+		}
+
+		public async Task<string> GetIssueOpenPullRequestUrlAsync(GetIssueOpenPullRequestUrl.Query query, CancellationToken cancellationToken = default)
         {
             return await Task.FromResult("https://github.com");
         }

--- a/src/Pet.Jira.Infrastructure/Mock/MockIssueMemoryCache.cs
+++ b/src/Pet.Jira.Infrastructure/Mock/MockIssueMemoryCache.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.Extensions.Options;
+using Pet.Jira.Application.Extensions;
+using Pet.Jira.Application.Storage;
+using Pet.Jira.Domain.Models.Issues;
+using Pet.Jira.Infrastructure.Jira;
+using System.Collections.Concurrent;
+using System.Threading.Tasks;
+
+namespace Pet.Jira.Infrastructure.Mock
+{
+    public class MockIssueMemoryCache : BaseMemoryCache<string, Issue>
+    {
+        private readonly IJiraConfiguration _jiraConfiguration;
+
+        public MockIssueMemoryCache(
+            IOptions<JiraConfiguration> jiraConfiguration)
+        {
+            _jiraConfiguration = jiraConfiguration.Value;
+        }
+
+        public override async Task<ConcurrentDictionary<string, Issue>> GetValuesAsync()
+        {
+            var storage = await base.GetValuesAsync();
+            if (storage.IsEmpty() && !_jiraConfiguration.CachedIssues.IsEmpty())
+            {
+                var issues = _jiraConfiguration.CachedIssues;
+                foreach (var issue in issues)
+                {
+                    TryAdd(new Issue { Key = issue, Summary = TextGenerator.Create(maxWords: 10, maxLetters: 10) });
+                }
+            }
+            return await base.GetValuesAsync();
+        }
+    }
+}

--- a/src/Pet.Jira.Infrastructure/Mock/MockServiceCollectionExtensions.cs
+++ b/src/Pet.Jira.Infrastructure/Mock/MockServiceCollectionExtensions.cs
@@ -3,6 +3,7 @@ using Pet.Jira.Application.Authentication;
 using Pet.Jira.Application.Issues;
 using Pet.Jira.Application.Storage;
 using Pet.Jira.Application.Worklogs;
+using Pet.Jira.Domain.Models.Issues;
 using Pet.Jira.Domain.Models.Users;
 
 namespace Pet.Jira.Infrastructure.Mock
@@ -16,6 +17,7 @@ namespace Pet.Jira.Infrastructure.Mock
             services.AddTransient<IAuthenticationService, MockAuthenticationService>();
             services.AddTransient<IIssueDataSource, MockIssueDataSource>();
             services.AddTransient<IStorage<string, UserProfile>, MockUserProfileStorage>();
+            services.AddTransient<IMemoryCache<string, Issue>, MockIssueMemoryCache>();
             return services;
         }
     }

--- a/src/Pet.Jira.Infrastructure/Mock/MockWorklogStorage.cs
+++ b/src/Pet.Jira.Infrastructure/Mock/MockWorklogStorage.cs
@@ -2,59 +2,11 @@
 using Pet.Jira.Domain.Models.Worklogs;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Pet.Jira.Infrastructure.Mock
 {
     internal static class MockWorklogStorage
     {
-        private static class IssueGenerator
-        {
-            public static Issue Create()
-            {
-                var key = $"CASEM-{new Random().Next(1000, 10000)}";
-                var summary = TextGenerator.Create();
-                return new Issue
-                {
-                    Key = key,
-                    Summary = summary,
-                    Link = "http://localhost"
-                };
-            }
-
-            public static string Text = "";
-        }
-
-        private static class TextGenerator
-        {
-            public static string Create()
-            {
-                Random random = new Random();
-                var builder = new StringBuilder();
-                var wordsCount = random.Next(5, 15);
-                char[] lowers = Enumerable.Range(0, 32).Select((x, i) => (char)('а' + i)).ToArray();
-                char[] uppers = Enumerable.Range(0, 32).Select((x, i) => (char)('А' + i)).ToArray();
-                for (int i = 0; i < wordsCount; i++)
-                {
-                    string word = string.Empty;
-                    var lettersCount = random.Next(5, 15);
-                    for (int j = 0; j < lettersCount; j++)
-                    {
-                        int letterPosition = random.Next(0, lowers.Length - 1);
-                        word += lowers[letterPosition];
-                    }
-
-                    builder.Append(word);
-                    builder.Append(" ");
-                }
-
-                return builder.ToString();
-            }
-
-            public static string Text = "";
-        }
-
         public static IList<Issue> Issues = new List<Issue>
         {
             IssueGenerator.Create(),
@@ -68,32 +20,38 @@ namespace Pet.Jira.Infrastructure.Mock
             IssueGenerator.Create()
         };
 
+        public static IssueWorklog CreateIssueWorklog(
+            DateTime startTime,
+            TimeSpan duration,
+            Issue issue)
+        {
+            return new IssueWorklog
+            {
+                StartDate = startTime,
+                CompleteDate = startTime.Add(duration),
+                TimeSpent = duration,
+                Issue = issue
+            };
+        }
+
         public static IList<IWorklog> IssueWorklogs = new List<IWorklog>
         {
-            new IssueWorklog
-            {
-                StartDate = DateTime.Now.Date.AddHours(11),
-                TimeSpent = TimeSpan.FromHours(1),
-                Issue = Issues[0]
-            },
-            new IssueWorklog
-            {
-                StartDate = DateTime.Now.Date.AddHours(13),
-                TimeSpent = TimeSpan.FromHours(2),
-                Issue = Issues[7]
-            },
-            new IssueWorklog
-            {
-                StartDate = DateTime.Now.Date.AddDays(-1).AddHours(16),
-                TimeSpent = TimeSpan.FromHours(5),
-                Issue = Issues[1]
-            },
-            new IssueWorklog
-            {
-                StartDate = DateTime.Now.Date.AddDays(-2).AddHours(19),
-                TimeSpent = TimeSpan.FromHours(8),
-                Issue = Issues[4]
-            }
+            CreateIssueWorklog(
+                startTime: DateTime.Now.Date.AddHours(11),
+                duration: TimeSpan.FromHours(1),
+                issue: Issues[0]),
+            CreateIssueWorklog(
+                startTime: DateTime.Now.Date.AddHours(13),
+                duration: TimeSpan.FromHours(2),
+                issue: Issues[7]),
+            CreateIssueWorklog(
+                startTime: DateTime.Now.Date.AddDays(-1).AddHours(16),
+                duration: TimeSpan.FromHours(5),
+                issue: Issues[1]),
+            CreateIssueWorklog(
+                startTime: DateTime.Now.Date.AddDays(-2).AddHours(19),
+                duration: TimeSpan.FromHours(8),
+                issue: Issues[4])
         };
 
         public static IList<IWorklog> RawIssueWorklogs = new List<IWorklog>

--- a/src/Pet.Jira.Infrastructure/Mock/TextGenerator.cs
+++ b/src/Pet.Jira.Infrastructure/Mock/TextGenerator.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Linq;
+using System.Text;
+
+namespace Pet.Jira.Infrastructure.Mock
+{
+    internal static class TextGenerator
+    {
+        public static string Create(
+            int minWords = 5,
+            int maxWords = 15,
+            int minLetters = 5,
+            int maxLetters = 15)
+        {
+            Random random = new Random();
+            var builder = new StringBuilder();
+            var wordsCount = random.Next(minWords, maxWords);
+            char[] lowers = Enumerable.Range(0, 32).Select((x, i) => (char)('а' + i)).ToArray();
+            char[] uppers = Enumerable.Range(0, 32).Select((x, i) => (char)('А' + i)).ToArray();
+            for (int i = 0; i < wordsCount; i++)
+            {
+                string word = string.Empty;
+                var lettersCount = random.Next(minLetters, maxLetters);
+                for (int j = 0; j < lettersCount; j++)
+                {
+                    int letterPosition = random.Next(0, lowers.Length - 1);
+                    word += lowers[letterPosition];
+                }
+
+                builder.Append(word);
+                builder.Append(' ');
+            }
+
+            return builder.ToString();
+        }
+    }
+}

--- a/src/Pet.Jira.Infrastructure/ServiceCollectionExtensions.cs
+++ b/src/Pet.Jira.Infrastructure/ServiceCollectionExtensions.cs
@@ -6,6 +6,7 @@ using Pet.Jira.Application.Storage;
 using Pet.Jira.Application.Users;
 using Pet.Jira.Application.Worklogs;
 using Pet.Jira.Application.Worklogs.Dto;
+using Pet.Jira.Domain.Models.Issues;
 using Pet.Jira.Domain.Models.Users;
 using Pet.Jira.Infrastructure.Authentication;
 using Pet.Jira.Infrastructure.Jira;
@@ -41,6 +42,7 @@ namespace Pet.Jira.Infrastructure
             services.AddTransient<IStorage<string, UserWorklogFilter>, UserWorklogFilterStorage>();
 
             services.AddSingleton<ILoginMemoryCache, LoginMemoryCache>();
+            services.AddTransient<IMemoryCache<string, Issue>, IssueMemoryCache>();
             return services;
         }
 

--- a/src/Pet.Jira.Web/Components/Worklogs/WorklogDay.razor
+++ b/src/Pet.Jira.Web/Components/Worklogs/WorklogDay.razor
@@ -6,11 +6,12 @@
 <tr class="pet-table-summary-tr">
     <td>
         <MudPaper Class="gap-1 d-flex flex-wrap border-none align-center pet-paper" Elevation="0" Width="100%">
-            <MudElement Class="flex-none d-flex gap-4 py-2 align-center" Style="width: 196px">
-                <MudElement Style="width: 128px">
+            <MudElement Class="flex-none d-flex gap-2 py-2 align-center">
+                <MudElement Style="width: 102px">
                     <MudProgressLinear Color="Color.Success" Size="Size.Small" Value="@Entity.Progress" />
                 </MudElement>
-                <MudElement Class="align-center" Style="width: 128px">
+                <WorklogDayMenu Entity=@Entity OnCreatedPressed="AddCustomWorklogAsync" />
+                <MudElement>
                     <b>@Entity.Date.ToString(DateFormats.DateFormat)</b>
                 </MudElement>
             </MudElement>

--- a/src/Pet.Jira.Web/Components/Worklogs/WorklogDay.razor.cs
+++ b/src/Pet.Jira.Web/Components/Worklogs/WorklogDay.razor.cs
@@ -39,5 +39,23 @@ namespace Pet.Jira.Web.Components.Worklogs
                 ErrorHandler.ProcessError(e);
             }
         }
+
+        private async Task AddCustomWorklogAsync(WorkingDayWorklog entity)
+        {
+            try
+            {
+                await Mediator.Send(new AddWorklog.Command(AddedWorklogDto.Create(entity)));
+                Entity.AddWorklog(entity);
+                Snackbar.Add(
+                    $"Worklog {entity.Issue.Key} added successfully!",
+                    Severity.Success,
+                    config => { config.ActionColor = Color.Success; });
+                StateHasChanged();
+            }
+            catch (Exception e)
+            {
+                ErrorHandler.ProcessError(e);
+            }
+        }
     }
 }

--- a/src/Pet.Jira.Web/Components/Worklogs/WorklogDayItemDialog.razor
+++ b/src/Pet.Jira.Web/Components/Worklogs/WorklogDayItemDialog.razor
@@ -1,0 +1,25 @@
+﻿@using Pet.Jira.Domain.Models.Issues;
+@using Pet.Jira.Infrastructure.Jira.Dto;
+@using Pet.Jira.Web.Components.Markdown
+
+<MudDialog>
+    <DialogContent>
+        <MudPaper Elevation="0" Class="pet-worklog-day-item-dialog">
+            <MudDatePicker Label="Date" @bind-Date="_model.Worklog.Date" />
+            <MudTimePicker Label="Start time" @bind-Time="_model.Worklog.StartTime" Editable="true" />
+            <MudTimePicker Label="Complete time" @bind-Time="_model.Worklog.CompleteTime" Editable="true" />
+            <MudAutocomplete T="Issue" Label="Issue" @bind-Value="_model.Worklog.Issue"
+                             SearchFunc="@SearchIssuesAsync"
+                             ToStringFunc="issue => issue?.Name"
+                             MaxItems="Int32.MaxValue"
+                             ResetValueOnEmptyText="true" Dense="true" />
+            <MudTextField Label="Comment" @bind-Value="_model.Worklog.Comment" />
+        </MudPaper>
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="Cancel">Cancel</MudButton>
+        <MudButton Color="Color.Primary" OnClick="Submit">Ok</MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {}

--- a/src/Pet.Jira.Web/Components/Worklogs/WorklogDayItemDialog.razor.cs
+++ b/src/Pet.Jira.Web/Components/Worklogs/WorklogDayItemDialog.razor.cs
@@ -1,0 +1,129 @@
+﻿using Microsoft.AspNetCore.Components;
+using MudBlazor;
+using Pet.Jira.Application.Issues;
+using Pet.Jira.Application.Storage;
+using Pet.Jira.Application.Worklogs.Dto;
+using Pet.Jira.Domain.Models.Issues;
+using Pet.Jira.Infrastructure.Jira;
+using Pet.Jira.Web.Shared;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Pet.Jira.Web.Components.Worklogs
+{
+    public partial class WorklogDayItemDialog : ComponentBase
+    {
+        private readonly ComponentModel _model = ComponentModel.Create();
+
+        [Parameter] public WorkingDay WorkingDay { get; set; }
+        [Parameter] public Color Color { get; set; } = Color.Default;
+        [Parameter] public string Icon { get; set; } = Icons.Material.Filled.MoreVert;
+        [Parameter] public string Label { get; set; } = "Default";
+
+        [CascadingParameter] public ErrorHandler ErrorHandler { get; set; }
+        [CascadingParameter] MudDialogInstance MudDialog { get; set; }
+
+        [Inject] private IMemoryCache<string, Issue> IssueCache { get; set; }
+		[Inject] private IIssueDataSource IssueDataSource { get; set; }
+
+		public class ComponentModel
+        {
+            public static ComponentModel Create()
+            {
+                return new ComponentModel();
+            }
+
+            public WorklogModel Worklog { get; set; } = new WorklogModel();
+        }
+
+        public class WorklogModel
+        {
+            [Required]
+            public DateTime? Date { get; set; }
+
+            [Required]
+            public TimeSpan? StartTime { get; set; }
+
+            [Required]
+            public TimeSpan? CompleteTime { get; set; }
+
+            [Required]
+            public string Comment { get; set; }
+
+            [Required]
+            public Issue Issue { get; set; }
+
+            public bool IsInitialized { get; set; }
+
+            public void Initialize(WorkingDay workingDay)
+            {
+                if (workingDay != null)
+                {
+                    Date = workingDay.Date;
+                    StartTime = workingDay.Settings.WorkingStartTime;
+                    CompleteTime = workingDay.Settings.WorkingStartTime.Add(new TimeSpan(0,15,0));
+                }
+            }
+
+            public WorkingDayWorklog Convert()
+            {
+                return new WorkingDayWorklog
+                {
+                    StartDate = Date.Value.Add(StartTime.Value),
+                    CompleteDate = Date.Value.Add(CompleteTime.Value),
+                    RawStartDate = Date.Value.Add(StartTime.Value),
+                    RawCompleteDate = Date.Value.Add(CompleteTime.Value),
+                    RemainingTimeSpent = CompleteTime.Value - StartTime.Value,
+                    Issue = Issue,
+                    Type = Domain.Models.Worklogs.WorklogType.Actual,
+                    Source = Domain.Models.Worklogs.WorklogSource.Calendar,
+                    Comment = Comment
+                };
+            }
+        }
+
+        protected override void OnInitialized()
+        {
+            _model.Worklog.Initialize(WorkingDay);
+        }
+
+        private async Task<IEnumerable<Issue>> SearchIssuesAsync(string value)
+        {
+            try
+            {
+                if (!string.IsNullOrWhiteSpace(value)
+					&& value.IsJiraKey())
+                {
+                    var issue = await IssueDataSource.GetIssueAsync(value);
+                    return issue is null
+                        ? Array.Empty<Issue>()
+                        : new[] { issue };
+				}
+                else
+                {
+					var issues = await IssueCache.GetValuesAsync();
+					return issues.Values.OrderBy(value => value.Identifier);
+				}
+            }
+            catch (Exception e)
+            {
+                ErrorHandler.ProcessError(e);
+                return _model.Worklog.Issue is null
+                    ? Array.Empty<Issue>()
+                    : new[] { _model.Worklog.Issue };
+            }
+        }
+
+        void Submit()
+        {
+            var worklog = _model.Worklog.Convert();
+            var result = DialogResult.Ok(worklog, typeof(WorkingDayWorklog));
+            MudDialog.Close(result);
+
+        }
+        void Cancel() => MudDialog.Cancel();
+    }
+}

--- a/src/Pet.Jira.Web/Components/Worklogs/WorklogDayMenu.razor
+++ b/src/Pet.Jira.Web/Components/Worklogs/WorklogDayMenu.razor
@@ -1,0 +1,10 @@
+﻿@using Pet.Jira.Web.Components.Markdown
+
+<MudMenu Icon="@Icon" Color="@Color" Size="Size.Small" Dense="true" Class="pet-vertical-align-middle"
+         AnchorOrigin=Origin.BottomLeft TransformOrigin=Origin.TopLeft Label="@Label">
+    <ChildContent>
+        <MudMenuItem OnClick="(async () => await AddCustomWorklog())">Add custom worklog</MudMenuItem>
+    </ChildContent>
+</MudMenu>
+
+@code {}

--- a/src/Pet.Jira.Web/Components/Worklogs/WorklogDayMenu.razor.cs
+++ b/src/Pet.Jira.Web/Components/Worklogs/WorklogDayMenu.razor.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.AspNetCore.Components;
+using MudBlazor;
+using Pet.Jira.Application.Worklogs.Dto;
+using Pet.Jira.Web.Shared;
+using System.Threading.Tasks;
+
+namespace Pet.Jira.Web.Components.Worklogs
+{
+    public partial class WorklogDayMenu : ComponentBase
+    {
+        [Parameter] public EventCallback<WorkingDayWorklog> OnCreatedPressed { get; set; }
+        [Parameter] public WorkingDay Entity { get; set; }
+        [Parameter] public Color Color { get; set; } = Color.Default;
+        [Parameter] public string Icon { get; set; } = Icons.Material.Filled.MoreVert;
+        [Parameter] public string Label { get; set; } = "Default";
+
+        [CascadingParameter] public ErrorHandler ErrorHandler { get; set; }
+
+        [Inject] IDialogService DialogService { get; set; }
+
+        private async Task AddCustomWorklog()
+        {
+            var options = new DialogOptions { };
+            var parameters = new DialogParameters
+            {
+                { "WorkingDay", Entity }
+            };
+            var dialog = await DialogService.ShowAsync<WorklogDayItemDialog>("New worklog", parameters, options);
+            var result = await dialog.Result;
+            if (result.Data is WorkingDayWorklog worklog)
+            {
+                await OnCreatedPressed.InvokeAsync(worklog);
+            }            
+        }
+    }
+}

--- a/src/Pet.Jira.Web/Shared/MainLayout.razor
+++ b/src/Pet.Jira.Web/Shared/MainLayout.razor
@@ -1,6 +1,10 @@
 ﻿@inherits LayoutComponentBase
 
-<MudDialogProvider />
+<MudDialogProvider MaxWidth="MaxWidth.Medium"
+                   CloseButton="true"
+                   DisableBackdropClick="true"
+                   Position="DialogPosition.Center"
+                   CloseOnEscapeKey="true" />
 <MudSnackbarProvider />
 
 <MudThemeProvider @bind-IsDarkMode="@_model.Theme.IsDarkMode" />

--- a/src/Pet.Jira.Web/appsettings.json
+++ b/src/Pet.Jira.Web/appsettings.json
@@ -8,7 +8,22 @@
   },
   "AllowedHosts": "*",
   "Jira": {
-    "Url": "https://jira.parcsis.org/"
+    "Url": "https://jira.parcsis.org/",
+    "CachedIssues": [
+      "CASEM-73656",
+      "CASEM-73652",
+      "CASEM-73654",
+      "CASEM-73657",
+      "CASEM-73658",
+      "CASEM-73659",
+      "CASEM-73660",
+      "CASEM-73661",
+      "CASEM-73653",
+      "CASEM-73655",
+      "CASEM-74557",
+      "CASEM-74558",
+      "CASEM-73661"
+    ]
   },
   "Serilog": {
     "MinimumLevel": {

--- a/src/Pet.Jira.Web/wwwroot/css/custom.css
+++ b/src/Pet.Jira.Web/wwwroot/css/custom.css
@@ -45,6 +45,10 @@
     width: 375px
 }
 
+.pet-worklog-day-item-dialog {
+    width: 475px
+}
+
 @media (max-width:320px) { /* smartphones, portrait iPhone, portrait 480x320 phones (Android) */
 }
 
@@ -54,6 +58,10 @@
     }
 
     .pet-worklog-day-chips-container {
+        width: 300px
+    }
+
+    .pet-worklog-day-item-dialog {
         width: 300px
     }
 }


### PR DESCRIPTION
# Custom worklog
Added the ability to create a custom worklog.
The worklog day item now has a context menu (⁝). In the drop-down list you can select "Add custom worklog". A pop-up window will appear with a preset date and time that corresponds to the start of the working day.

![image](https://github.com/tolmachev-pravo/pet-jira-workflow/assets/62241382/008ccca4-41f6-40c7-9aa2-332052190a0f)

The "Issue" list is preconfigured by default and corresponds to the list of cached elements, which is configured at the configuration file through the "CachedIssues" parameter.
If you want to log time for a specific task, then in the Issue search you need to enter the number of this Issue. The application itself will pull the necessary data from Jira.

![image](https://github.com/tolmachev-pravo/pet-jira-workflow/assets/62241382/833fb618-f29b-47de-8a35-20b11ae93d94)

You can leave a free comment. If it is not specified, then by default the comment will be logged in the "Discussion [issue number]" format.

_Enjoy your use_